### PR TITLE
Post thumbnail support

### DIFF
--- a/wds-multisite-aggregate.php
+++ b/wds-multisite-aggregate.php
@@ -309,8 +309,8 @@ class WDS_Multisite_Aggregate {
 
 		$this->meta_to_sync['permalink'] = get_permalink( $post_id );
 		$this->meta_to_sync['blogid'] = $post_blog_id; // org_blog_id
-
-        // Post thumbnail
+		
+		// Post thumbnail
 		if ( $this->options->get( 'tags_blog_thumbs' ) && ( $thumb_id = get_post_thumbnail_id( $post->ID ) ) ) {
 			
 			// URL for later import in aggregating blog


### PR DESCRIPTION
This fixes issue #5 :

- Thumbnail image copied into the aggregating blog's Media library, attached to synced post
- Copied image set as post thumbnail for the corresponding post
- If thumbnail is changed or removed in subsite, change is replicated on aggregating blog

Could be coded more cleanly. All the image stuff in its own class, for example, but I'm pretty sure my code is closer to the coding guidelines than what's already in there, so I'm OK with the current state of affairs. I would really like this to be merged, though, so I'll do what you want. Cheers!

Oh! I forgot. One or two methods were ripped from[ Automattic's aggregator](https://github.com/Automattic/aggregator), so contributors list should be modified accordingly.